### PR TITLE
docs: add note about when the public API is available

### DIFF
--- a/devops-guides/how-to-setup-a-node-with-docker.md
+++ b/devops-guides/how-to-setup-a-node-with-docker.md
@@ -61,6 +61,8 @@ docker-compose up -d
 
 This will run two separate containers. One for Core itself and another one for PostgreSQL.
 
+Remember that the API will be available only after the relay finishes the update. Until there, the container will respond with `Connection reset by peer` to any request made any of its ports. 
+
 ### How To Run a Relay and a Forger Node
 
 #### Prerequisites to be installed:

--- a/devops-guides/how-to-setup-a-node-with-docker.md
+++ b/devops-guides/how-to-setup-a-node-with-docker.md
@@ -61,7 +61,7 @@ docker-compose up -d
 
 This will run two separate containers. One for Core itself and another one for PostgreSQL.
 
-Remember that the API will be available only after the relay finishes the update. Until there, the container will respond with `Connection reset by peer` to any request made any of its ports. 
+The public API won't be available until a relay is fully synchronized with the network and blockchain. All requests before this will result in a connection reset because the port is not yet bound to an application.
 
 ### How To Run a Relay and a Forger Node
 
@@ -278,4 +278,3 @@ _Need to start everything from scratch and make sure there are no remaining cach
 {% hint style="danger" %}
 **Development files/presets are not Production ready**. Official Production ARK-Core Docker images are now available at [Docker Hub](https://hub.docker.com/r/arkecosystem/core).
 {% endhint %}
-


### PR DESCRIPTION
Adds a `reminder` that API only responds after the synchronization (since https://github.com/ArkEcosystem/core/issues/2826 says that is probably mentioned elsewhere).

I've added this after spending some time searching for a solution over the docker layer, since this can happen due to port forwarding issues.